### PR TITLE
iOS12 click bug

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "adapt-contrib-hotgraphic",
-  "version": "4.3.0",
+  "version": "4.3.1",
   "framework": ">=3.3",
   "homepage": "https://github.com/adaptlearning/adapt-contrib-hotgraphic",
   "issues": "https://github.com/adaptlearning/adapt_framework/issues/new",

--- a/js/hotgraphicPopupView.js
+++ b/js/hotgraphicPopupView.js
@@ -13,6 +13,8 @@ define([
         },
 
         initialize: function() {
+            // Debounce required as a second (bad) click event is dispatched on iOS causing a jump of two items.
+            this.onControlClick = _.debounce(this.onControlClick.bind(this), 100);
             this.listenToOnce(Adapt, "notify:opened", this.onOpened);
             this.listenTo(this.model.get('_children'), {
                 'change:_isActive': this.onItemsActiveChange,


### PR DESCRIPTION
Stop hotgraphic (notify) pop up controls from triggering two clicks when pressed in iOS 12

Resolves [#2622](https://github.com/adaptlearning/adapt_framework/issues/2622)